### PR TITLE
Fix arXiv ingestion DAG import dependencies

### DIFF
--- a/ai-engine/airflow/dags/arxiv_ingestion_dag.py
+++ b/ai-engine/airflow/dags/arxiv_ingestion_dag.py
@@ -20,20 +20,42 @@
 #   the DAG will try to build a SQLAlchemy URL from this connection.
 
 import os
-import json
+import importlib
+from functools import lru_cache
 from datetime import datetime, timedelta
 from typing import Any, Dict, List
 
 from airflow import DAG
 from airflow.decorators import task
 from airflow.models import Variable
-from airflow.exceptions import AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.hooks.base import BaseHook
 
-# We import the utility functions from your repository modules
-# Make sure these files are available in PYTHONPATH inside the Airflow containers.
-from test_arXiv import load_config, fetch_and_parse, normalize_entries
-from utils.persistence import save_papers
+
+@lru_cache
+def _get_etl_module():
+    """Lazy-load the arXiv ETL helpers so DAG parsing works without extras."""
+    try:
+        return importlib.import_module("test_arXiv")
+    except ModuleNotFoundError as exc:  # pragma: no cover - protective guard
+        raise AirflowException(
+            "Module 'test_arXiv' is required by arxiv_ingestion_dag but is not "
+            "available in the Airflow image. Install the ETL dependencies "
+            "(xmltodict, requests, PyYAML, etc.) inside the scheduler/worker "
+            "environment."
+        ) from exc
+
+
+@lru_cache
+def _get_persistence_module():
+    """Lazy-load persistence utilities while providing a helpful error message."""
+    try:
+        return importlib.import_module("utils.persistence")
+    except ModuleNotFoundError as exc:  # pragma: no cover - protective guard
+        raise AirflowException(
+            "Module 'utils.persistence' is missing. Ensure the ai-engine/utils "
+            "package is on PYTHONPATH inside the Airflow container."
+        ) from exc
 
 
 def _get_bool(var_name: str, default: bool) -> bool:
@@ -96,7 +118,8 @@ with DAG(
         Returns the effective config dict.
         """
         cfg_path = Variable.get("CONFIG_PATH", default_var="config.yaml")
-        cfg = load_config(cfg_path)
+        etl = _get_etl_module()
+        cfg = etl.load_config(cfg_path)
 
         # Apply hot overrides
         q = Variable.get("ARXIV_QUERY", default_var=None)
@@ -132,7 +155,8 @@ with DAG(
         """
         Fetch Atom feed and return raw entries.
         """
-        entries = fetch_and_parse(cfg)
+        etl = _get_etl_module()
+        entries = etl.fetch_and_parse(cfg)
         # Small guard: skip DAG if nothing fetched
         if not entries:
             raise AirflowSkipException("No entries fetched from arXiv.")
@@ -143,7 +167,8 @@ with DAG(
         """
         Normalize raw entries into records expected by save_papers().
         """
-        records = normalize_entries(entries, cfg)
+        etl = _get_etl_module()
+        records = etl.normalize_entries(entries, cfg)
         if not records:
             raise AirflowSkipException("No records after normalization.")
         return records
@@ -154,7 +179,8 @@ with DAG(
         Persist records with atomic, idempotent upsert. Returns saved count.
         """
         pg_url = cfg.get("database", {}).get("postgres_url") or resolve_postgres_url()
-        save_papers(pg_url, records)
+        persistence = _get_persistence_module()
+        persistence.save_papers(pg_url, records)
         return len(records)
 
     # Task wiring

--- a/ai-engine/airflow/requirements-etl.txt
+++ b/ai-engine/airflow/requirements-etl.txt
@@ -1,0 +1,4 @@
+# Additional runtime deps required for arxiv_ingestion_dag
+xmltodict>=0.13
+psycopg2-binary>=2.9
+PyYAML>=6.0

--- a/ai-engine/docker/Dockerfile.airflow
+++ b/ai-engine/docker/Dockerfile.airflow
@@ -41,6 +41,10 @@ RUN pip install --no-cache-dir \
 # Install FAB auth manager separately to handle Flask version conflicts (like POC)
 RUN pip install --no-cache-dir apache-airflow-providers-fab
 
+# Install lightweight ETL dependencies required during DAG parsing/runtime
+COPY --chown=airflow:root ./airflow/requirements-etl.txt /opt/airflow/requirements-etl.txt
+RUN pip install --no-cache-dir -r /opt/airflow/requirements-etl.txt
+
 
 # Copy application code
 COPY --chown=airflow:root ./airflow/dags /opt/airflow/dags/

--- a/ai-engine/utils/__init__.py
+++ b/ai-engine/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers for the ai-engine package."""
+
+__all__ = [
+    "persistence",
+]


### PR DESCRIPTION
## Summary
- defer importing the arXiv ETL helpers and persistence utilities until task runtime so the DAG can parse even if optional packages are missing
- add a lightweight requirements file for the ETL stack and install it in the Airflow Docker image
- mark utils as a package so persistence helpers can be resolved reliably inside the Airflow container

## Testing
- python -m compileall ai-engine/airflow/dags/arxiv_ingestion_dag.py

------
https://chatgpt.com/codex/tasks/task_e_68de80e3b160832b90357af75b77012b